### PR TITLE
feat: support setting initial progress when emitting facile danmaku

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -129,6 +129,10 @@ export const en: LocaleSpecificConfig<DefaultTheme.Config> = {
             text: 'Live Streaming and Video',
             link: '/en/cases/recommend',
           },
+          {
+            text: 'Setting Initial Progress',
+            link: '/en/cases/danmaku-progress',
+          },
         ],
       },
     ],

--- a/docs/.vitepress/config/zh.ts
+++ b/docs/.vitepress/config/zh.ts
@@ -127,6 +127,10 @@ export const zh: LocaleSpecificConfig<DefaultTheme.Config> = {
             text: '直播和视频场景的建议',
             link: '/zh/cases/recommend',
           },
+          {
+            text: '弹幕初始进度',
+            link: '/zh/cases/danmaku-progress',
+          },
         ],
       },
     ],

--- a/docs/en/cases/danmaku-progress.md
+++ b/docs/en/cases/danmaku-progress.md
@@ -1,0 +1,57 @@
+# Danmaku Initial Progress
+
+## Description
+
+The `progress` property controls the initial progress of danmaku. `progress` is a value ranging from `[0, 1]` that
+sets the starting position when the danmaku begins playing. This is useful for "prefilling" the screen when seeking or
+scrubbing in a video.
+
+> [!NOTE] Hint
+>
+> 1. When `progress` is `0`, the danmaku starts from the beginning (default behavior)
+> 2. When `progress` is `1`, the danmaku starts from the end (finishes immediately)
+> 3. When `progress` is `0.5`, the danmaku starts at the halfway point
+> 4. This is only useful for facile danmaku
+
+## Basic Usage
+
+```ts
+manager.push('This danmaku starts from 30%', {
+    progress: 0.3
+});
+
+manager.push('This danmaku starts from 80%', {
+    progress: 0.8
+});
+```
+
+## Emitting Danmaku After a Seek
+
+After a seek operation, you may want to emit danmaku that starts at a specific time relative to the current playback
+position. This can be achieved by calculating the `progress` based on the current time and the desired start time of the
+danmaku.
+
+```ts
+const DANMAKU_DURATION = 5; // seconds
+
+function onSeek() {
+    // clear all existing danmaku
+    manager.clear()
+
+    // get a list of danmaku starting at 5 seconds before the current time
+    const danmakus = getDanmakuStartingAt(video.currentTime - DANMAKU_DURATION)
+
+    danmakus.forEach(({time, text}) => {
+        // compute the progress for each danmaku
+        const progress = (video.currentTime - comment.time) / DANMAKU_DURATION
+
+        // The ones that are before video.currentTime will have progress > 0, 
+        // so they will appear immediately in the middle of the screen instead of the edges
+        manager.push(text, {
+            progress
+        });
+    })
+}
+
+video.addEventListener('seeking', onSeek)
+```

--- a/docs/en/reference/manager-api.md
+++ b/docs/en/reference/manager-api.md
@@ -43,6 +43,7 @@ export interface PushOptions<T> {
   speed?: number | string | null; // Higher priority than `duration`
   plugin?: DanmakuPlugin<T>;
   direction?: 'right' | 'left';
+  progress?: number;
 }
 ```
 

--- a/docs/zh/cases/danmaku-progress.md
+++ b/docs/zh/cases/danmaku-progress.md
@@ -1,0 +1,53 @@
+# 弹幕初始进度
+
+## 描述
+
+`progress` 属性用于控制弹幕的初始进度。`progress` 是一个取值范围为 `[0, 1]` 的数值，用于设置弹幕开始播放时的起始位置。可以用于视频定位或拖拽后填充屏幕。
+
+> [!NOTE] 提示
+>
+> 1. `progress` 值为 `0` 时，弹幕从起始位置开始播放（默认行为）
+> 2. `progress` 值为 `1` 时，弹幕从结束位置开始播放（立即结束）
+> 3. `progress` 值为 `0.5` 时，弹幕从中间位置开始播放
+> 4. 仅对普通弹幕有效
+
+## 基本用法
+
+```ts
+manager.push('这条弹幕从 30% 的位置开始', {
+    progress: 0.3
+});
+
+manager.push('这条弹幕从 80% 的位置开始', {
+    progress: 0.8
+});
+```
+
+## 视频定位
+
+定位后通常会清空弹幕，此时新的弹幕会从视频边缘开始滚动，导致视频中间出现一段的弹幕空挡。此时可以使用 `progress` 来发送当前播放位置之前的弹幕以填充屏幕。
+
+```ts
+const DANMAKU_DURATION = 5; // 秒
+
+function onSeek() {
+    // 清空屏幕
+    manager.clear()
+
+    // 获取从当前时间前5秒开始的弹幕列表
+    const comments = getCommentsStartingAt(video.currentTime - DANMAKU_DURATION)
+
+    comments.forEach(({time, text}) => {
+        // 计算每条弹幕的进度
+        const progress = (video.currentTime - comment.time) / DANMAKU_DURATION
+
+        // 在 video.currentTime 之前的弹幕进度 > 0，
+        // 所以会立即出现在屏幕中间某处而不是从边缘开始
+        manager.push(text, {
+            progress
+        });
+    })
+}
+
+video.addEventListener('seeking', onSeek)
+``` 

--- a/docs/zh/reference/manager-api.md
+++ b/docs/zh/reference/manager-api.md
@@ -43,6 +43,7 @@ export interface PushOptions<T> {
   speed?: number | string | null; // 优先级比 `duration` 更高
   plugin?: DanmakuPlugin<T>;
   direction?: 'right' | 'left';
+  progress?: number;
 }
 ```
 

--- a/src/danmaku/facile.ts
+++ b/src/danmaku/facile.ts
@@ -174,24 +174,15 @@ export class FacileDanmaku<T> {
         ? this.hide(INTERNAL_FLAG)
         : this.show(INTERNAL_FLAG);
 
+      const actualDuration = this.actualDuration();
+      this.setStyle('transform', `translateX(${negative * cw}px)`);
+      this.setStyle('transition', `transform linear ${actualDuration}ms`);
+
       if (this._options.progress && this._options.progress > 0) {
-        const startingPosition = negative * cw * this._options.progress;
-        this.setStyle('transform', `translateX(${startingPosition}px)`);
-
-        const remainingTime =
-          (1 - this._options.progress) * this.actualDuration();
-
-        nextFrame(() => {
-          this.setStyle('transition', `transform linear ${remainingTime}ms`);
-          this.setStyle('transform', `translateX(${negative * cw}px)`);
-        });
-      } else {
-        this.setStyle('transform', `translateX(${negative * cw}px)`);
-        this.setStyle(
-          'transition',
-          `transform linear ${this.actualDuration()}ms`,
-        );
+        const remainingTime = this._options.progress * actualDuration;
+        this.setStyle('transitionDelay', `${-1 * remainingTime}ms`);
       }
+
       if (this.direction !== 'none') {
         this.setStyle(this.direction, `-${w}px`);
       }
@@ -372,6 +363,7 @@ export class FacileDanmaku<T> {
     this.setStyle('zIndex', '0');
     this.setStyle('transitionDuration', `${remainingTime}ms`);
     this.setStyle('transform', `translateX(${cw * negative}px)`);
+    this.setStyle('transitionDelay', '');
     if (_flag !== INTERNAL_FLAG) {
       this.pluginSystem.lifecycle.resume.emit(this);
     }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -442,6 +442,7 @@ export class Engine<T> {
       container: this.container,
       duration: options.duration,
       direction: options.direction,
+      progress: options.progress,
       delInTrack: (b: Danmaku<T>) => {
         remove(this._sets.view, b);
         type === 'facile'

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface PushOptions<T> {
   plugin?: DanmakuPlugin<T>;
   rate?: ManagerOptions['rate'];
   direction?: ManagerOptions['direction'];
+  progress?: number;
 }
 
 export interface EngineOptions {


### PR DESCRIPTION
closes #31
maybe #39 too

added a "progress" option, a value between [0, 1], to determine the initial position of the emitted facile danmaku

use case demo
## no initial progress
https://github.com/user-attachments/assets/2048c793-692d-4a1e-a803-d82bb417ac97

## with initial progress

https://github.com/user-attachments/assets/efbe6b69-f959-4ac9-83cc-1d3238b04d47

