### PR TITLE
feat: add option to change danmu distribution

### DIFF
--- a/demo/src/components/sidebar/SidebarDistribution.tsx
+++ b/demo/src/components/sidebar/SidebarDistribution.tsx
@@ -1,0 +1,62 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { List, CircleAlert } from 'lucide-react';
+import type { Manager, ManagerOptions } from 'danmu';
+import type { DanmakuValue } from '@/types';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+export const SidebarDistribution = memo(
+  ({ manager }: { manager: Manager<DanmakuValue> }) => {
+    const { t } = useTranslation();
+
+    return (
+      <div className="flex h-8 mb-4 items-center justify-between">
+        <Label className="shrink-0 mr-3 h-full text-base font-bold leading-8">
+          <div className="flex items-center">
+            <List />
+            <span className="ml-3 mr-1">{t('setDistribution')}</span>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <CircleAlert size={16} className="cursor-pointer" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  {t('setDistributionTipTitle')}
+                  <br />
+                  1. {t('setDistributionTipOne')}
+                  <br />
+                  2. {t('setDistributionTipTwo')}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        </Label>
+        <Tabs
+          defaultValue="random"
+          onFocus={(e) =>
+            manager.updateOptions({
+              distribution:
+                e.target.textContent?.trim() as ManagerOptions['distribution'],
+            })
+          }
+        >
+          <TabsList>
+            <TabsTrigger className="px-2 font-bold" value="random">
+              random
+            </TabsTrigger>
+            <TabsTrigger className="px-2 font-bold" value="order">
+              order
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+    );
+  },
+);

--- a/demo/src/components/sidebar/SidebarOverlap.tsx
+++ b/demo/src/components/sidebar/SidebarOverlap.tsx
@@ -1,0 +1,49 @@
+import { memo } from 'react';
+
+import { useTranslation } from 'react-i18next';
+import { Layers, CircleAlert } from 'lucide-react';
+import type { Manager } from 'danmu';
+import type { DanmakuValue } from '@/types';
+import { Label } from '@/components/ui/label';
+import { Slider } from '@/components/ui/slider';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+export const SidebarOverlap = memo(
+  ({ manager }: { manager: Manager<DanmakuValue> }) => {
+    const { t } = useTranslation();
+
+    return (
+      <div className="flex h-8 mb-4 items-center justify-between">
+        <Label className="shrink-0 mr-3 h-full text-base font-bold leading-8">
+          <div className="flex items-center">
+            <Layers size={20} />
+            <span className="ml-3 mr-1">{t('setOverlap')}</span>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <CircleAlert size={16} className="cursor-pointer" />
+                </TooltipTrigger>
+                <TooltipContent>{t('setOverlapTip')}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        </Label>
+        <Slider
+          className="flex-1"
+          max={1}
+          min={0}
+          step={0.1}
+          defaultValue={[0]}
+          onValueChange={([val]) => {
+            manager.setOverlap(val);
+          }}
+        />
+      </div>
+    );
+  },
+);

--- a/demo/src/components/sidebar/index.tsx
+++ b/demo/src/components/sidebar/index.tsx
@@ -1,6 +1,7 @@
 import type { Manager } from 'danmu';
 import type { DanmakuValue } from '@/types';
 import { SidebarGap } from '@/components/sidebar/SidebarGap';
+import { SidebarOverlap } from '@/components/sidebar/SidebarOverlap';
 import { SidebarRate } from '@/components/sidebar/SidebarRate';
 import { SidebarSpeed } from '@/components/sidebar/SidebarSpeed';
 import { SidebarAreaX } from '@/components/sidebar/SidebarAreaX';
@@ -24,6 +25,7 @@ export const Sidebar = ({ manager }: { manager: Manager<DanmakuValue> }) => {
       <SidebarAreaX manager={manager} />
       <SidebarAreaY manager={manager} />
       <SidebarGap manager={manager} />
+      <SidebarOverlap manager={manager} />
       <SidebarFrequency manager={manager} />
       <SidebarMoveDuration manager={manager} />
       <SidebarRate manager={manager} />

--- a/demo/src/components/sidebar/index.tsx
+++ b/demo/src/components/sidebar/index.tsx
@@ -15,6 +15,7 @@ import { SidebarModeSelect } from '@/components/sidebar/SidebarModeSelect';
 import { SidebarShowAndHide } from '@/components/sidebar/SidebarShowAndHide';
 import { SidebarMoveDuration } from '@/components/sidebar/SidebarMoveDuration';
 import { SidebarStartAndStop } from '@/components/sidebar/SidebarStartAndStop';
+import { SidebarDistribution } from '@/components/sidebar/SidebarDistribution';
 
 export const Sidebar = ({ manager }: { manager: Manager<DanmakuValue> }) => {
   return (
@@ -28,6 +29,7 @@ export const Sidebar = ({ manager }: { manager: Manager<DanmakuValue> }) => {
       <SidebarRate manager={manager} />
       <SidebarSpeed manager={manager} />
       <SidebarModeSelect manager={manager} />
+      <SidebarDistribution manager={manager} />
       <SidebarFreeze manager={manager} />
       <SidebarOcclusion manager={manager} />
       <SidebarDirection manager={manager} />

--- a/demo/src/i18n/en.ts
+++ b/demo/src/i18n/en.ts
@@ -34,6 +34,11 @@ export const enMap = {
     'When set to `strict` mode, strict collision detection will be performed, and if the conditions are not met, rendering will be delayed',
   setModeTipThree:
     'When set to `adaptive` mode, collision detection will be performed as much as possible under the premise of immediate rendering (recommended)',
+  setDistribution: 'Distribution',
+  setDistributionTipTitle:
+    'Controls how the engine selects a track for the danmaku',
+  setDistributionTipOne: 'Random: randomly selects a track',
+  setDistributionTipTwo: 'Order: selects tracks in order from top to bottom',
   setDuration: 'Duration',
   setDurationTip:
     'Normal danmaku will randomly take a value between these two values as the movement duration',

--- a/demo/src/i18n/en.ts
+++ b/demo/src/i18n/en.ts
@@ -25,6 +25,10 @@ export const enMap = {
   setGap: 'Gap between danmaku',
   setGapTip:
     'In the case of collision detection on the same track, the minimum distance between the following danmaku and the previous danmaku',
+  setOverlap: 'Overlap ratio',
+  setOverlapTip:
+    'Adjust how much overlap is allowed in strict mode (0 = no overlap, 1 = full overlap). This scales the width used for collision detection.',
+  danmakuOverlap: 'Overlap',
   setMode: 'Mode',
   setModeTipTitle:
     'The rendering mode determines the collision detection rules and the timing of danmaku rendering',

--- a/demo/src/i18n/zh.ts
+++ b/demo/src/i18n/zh.ts
@@ -31,6 +31,10 @@ export const zhMap = {
     '当设置为 strict 模式时，会进行严格的碰撞检测，如果不满足条件则会推迟渲染',
   setModeTipThree:
     '当设置为 adaptive 模式时，在满足立即渲染的前提下，会尽力进行碰撞检测（推荐）',
+  setDistribution: '分发方式',
+  setDistributionTipTitle: '控制引擎如何为弹幕选择轨道',
+  setDistributionTipOne: 'Random: 随机选择轨道',
+  setDistributionTipTwo: 'Order: 从上到下按顺序选择轨道',
   setDuration: '运动时长',
   setDurationTip: '普通弹幕会从这两个值之间随机取一个值作为弹幕运动的时间',
   setNumbersTitle: '实时渲染弹幕',

--- a/demo/src/i18n/zh.ts
+++ b/demo/src/i18n/zh.ts
@@ -24,6 +24,10 @@ export const zhMap = {
   setGap: '弹幕之间的间距',
   setGapTip:
     '同一条轨道在碰撞检测的啥情况下，后一条弹幕与前一条弹幕最小相隔的距离',
+  setOverlap: '重叠比例',
+  setOverlapTip:
+    '调节严格模式下允许的重叠程度（0 = 不重叠，1 = 完全重叠）。这会缩放用于碰撞检测的宽度。',
+  danmakuOverlap: '重叠程度',
   setMode: '渲染模式',
   setModeTipTitle: '渲染模式决定着碰撞检测的规则和弹幕渲染的时机',
   setModeTipOne: '当设置为 none 模式时，不会有任何碰撞检测，弹幕会立即渲染',

--- a/demo/src/manager.tsx
+++ b/demo/src/manager.tsx
@@ -10,6 +10,7 @@ export const initManager = () => {
     interval: 100,
     trackHeight: 40,
     durationRange: [10000, 13000],
+    distribution: 'random',
     plugin: {
       init(manager) {
         'shadow shadow-slate-200 bg-slate-100'.split(' ').forEach((c) => {

--- a/docs/en/reference/manager-configuration.md
+++ b/docs/en/reference/manager-configuration.md
@@ -142,6 +142,16 @@ The movement duration for regular danmaku. This is a range value, and **regular 
 
 - `stash` limits the number of danmaku stored in memory. If this limit is exceeded, they will be discarded and an alert will be triggered or a plugin hook will be called. You can adjust this parameter as needed.
 
+## `config.distribution`
+
+**Type: `'random' | 'order'`**<br/>
+**Default: `'random'`**
+
+Controls how the engine selects a track for the danmaku.
+
+- **`random`** Randomly selects a track.
+- **`order`** Selects tracks in order from top to bottom.
+
 ## `config.plugin`
 
 **Type: `ManagerPlugin<unknown> | Array<ManagerPlugin<unknown>>`**<br/>

--- a/docs/zh/reference/manager-configuration.md
+++ b/docs/zh/reference/manager-configuration.md
@@ -141,6 +141,16 @@ manager.setTrackHeight('33%'); // 高度为容器高度的 33%
 - `view` 限制渲染在容器中的弹幕数量，如果超过了此限制，普通弹幕会放在内存中，等待合适的时机渲染，高级弹幕会直接丢弃。
 - `stash` 限制存放在内存中的弹幕数量，如果超过此限制则会被丢弃，并触发告警或调用插件钩子，你可以适当调整此参数。
 
+## `config.distribution`
+
+**类型: `'random' | 'order'`**<br/>
+**默认值: `'random'`**
+
+控制引擎如何为弹幕选择轨道。
+
+- **`random`** 随机选择轨道。
+- **`order`** 从上到下按顺序选择轨道。
+
 ## `config.plugin`
 
 **类型：`ManagerPlugin<unknown> | Array<ManagerPlugin<unknown>>`**<br/>

--- a/src/danmaku/facile.ts
+++ b/src/danmaku/facile.ts
@@ -448,7 +448,6 @@ export class FacileDanmaku<T> {
 
   public hide(_flag?: Symbol) {
     this.setStyle('visibility', 'hidden');
-    this.setStyle('pointerEvents', 'none');
     if (_flag !== INTERNAL_FLAG) {
       this.pluginSystem.lifecycle.hide.emit(this);
     }
@@ -456,7 +455,6 @@ export class FacileDanmaku<T> {
 
   public show(_flag?: Symbol) {
     this.setStyle('visibility', 'visible');
-    this.setStyle('pointerEvents', 'auto');
     if (_flag !== INTERNAL_FLAG) {
       this.pluginSystem.lifecycle.show.emit(this);
     }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -242,9 +242,9 @@ export class Engine<T> {
         this._sets.flexible.add(dm as FlexibleDanmaku<T>);
         this._setAction(dm, statuses).then((isFreeze) => {
           if (isFreeze) {
-            console.error(
-              'Currently in a freeze state, unable to render "FlexibleDanmaku"',
-            );
+            // console.error(
+            //   'Currently in a freeze state, unable to render "FlexibleDanmaku"',
+            // );
             return;
           }
           if (dm.isLoop) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -88,6 +88,12 @@ export class Engine<T> {
     if (hasOwn(newOptions, 'gap')) {
       this._options.gap = this.container._toNumber('width', this._options.gap);
     }
+    if (hasOwn(newOptions, 'overlap')) {
+      let overlap = this._options.overlap!;
+      if (overlap < 0) overlap = 0;
+      if (overlap > 1) overlap = 1;
+      this._options.overlap = overlap;
+    }
     if (hasOwn(newOptions, 'trackHeight')) {
       this.format();
     }
@@ -557,7 +563,8 @@ export class Engine<T> {
     const acceleration = cs - ps;
     if (acceleration <= 0) return null;
 
-    const cw = cur.getWidth();
+    const overlap = this._options.overlap!;
+    const cw = cur.getWidth() * (1 - overlap);
     const pw = prv.getWidth();
     const { gap } = this._options;
     const distance = prv._getMoveDistance() - cw - pw - (gap as number);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -14,7 +14,12 @@ import { Container } from './container';
 import { FacileDanmaku } from './danmaku/facile';
 import { FlexibleDanmaku } from './danmaku/flexible';
 import { type createManagerLifeCycle } from './lifeCycle';
-import { getTrackIdx, nextFrame, INTERNAL_FLAG } from './utils';
+import {
+  getTrackIdx,
+  nextFrame,
+  INTERNAL_FLAG,
+  getTrackRandomIdx,
+} from './utils';
 import type {
   Speed,
   StashData,
@@ -39,6 +44,7 @@ export class Engine<T> {
     flexible: new Set<FlexibleDanmaku<T>>(),
     stash: [] as Array<StashData<T> | FacileDanmaku<T>>,
   };
+  private _retryMap = new WeakMap<object, number>();
   // Avoid frequent deletion of danmaku.
   // collect the danmaku that need to be deleted within 2 seconds and delete them together.
   private _addDestroyQueue = batchProcess<Danmaku<T>>({
@@ -346,7 +352,15 @@ export class Engine<T> {
           if (isStash) {
             dm._reset();
             this._sets.view.delete(dm);
-            this._sets.stash.unshift(dm);
+            const retries = (this._retryMap.get(dm) || 0) + 1;
+            this._retryMap.set(dm, retries);
+            if (retries > 1 && this.len().stash > 100) {
+              // discard the danmaku when we have a lot of stash danmaku
+              this._retryMap.delete(dm);
+              this._addDestroyQueue(dm);
+            } else {
+              this._sets.stash.unshift(dm);
+            }
             return;
           }
           if (dm.isLoop) {
@@ -502,14 +516,17 @@ export class Engine<T> {
     return s as Nullable<number>;
   }
 
-  private _getTrack(
-    founds = new Set<number>(),
-    prev?: Track<T>,
-  ): Track<T> | null {
+  private _getTrackRandom(): Track<T> | null {
+    const i = getTrackRandomIdx(this.rows);
+    const track = this.tracks[i];
+    return track ?? null;
+  }
+
+  private _getTrack(founds = new Set<number>()): Track<T> | null {
     if (this.rows === 0) return null;
     const { gap, mode, distribution } = this._options;
     if (founds.size === this.tracks.length) {
-      return mode === 'adaptive' ? prev || null : null;
+      return mode === 'adaptive' ? (this._getTrackRandom() ?? null) : null;
     }
     const i = getTrackIdx(founds, this.rows, distribution);
     const track = this.tracks[i];
@@ -531,7 +548,7 @@ export class Engine<T> {
       }
     }
     founds.add(i);
-    return this._getTrack(founds, track);
+    return this._getTrack(founds);
   }
 
   private _collisionPrediction(prv: FacileDanmaku<T>, cur: FacileDanmaku<T>) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -14,7 +14,7 @@ import { Container } from './container';
 import { FacileDanmaku } from './danmaku/facile';
 import { FlexibleDanmaku } from './danmaku/flexible';
 import { type createManagerLifeCycle } from './lifeCycle';
-import { randomIdx, nextFrame, INTERNAL_FLAG } from './utils';
+import { getTrackIdx, nextFrame, INTERNAL_FLAG } from './utils';
 import type {
   Speed,
   StashData,
@@ -507,11 +507,11 @@ export class Engine<T> {
     prev?: Track<T>,
   ): Track<T> | null {
     if (this.rows === 0) return null;
-    const { gap, mode } = this._options;
+    const { gap, mode, distribution } = this._options;
     if (founds.size === this.tracks.length) {
       return mode === 'adaptive' ? prev || null : null;
     }
-    const i = randomIdx(founds, this.rows);
+    const i = getTrackIdx(founds, this.rows, distribution);
     const track = this.tracks[i];
 
     if (!track.isLock) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -91,7 +91,6 @@ export class Engine<T> {
     if (hasOwn(newOptions, 'overlap')) {
       let overlap = this._options.overlap!;
       if (overlap < 0) overlap = 0;
-      if (overlap > 1) overlap = 1;
       this._options.overlap = overlap;
     }
     if (hasOwn(newOptions, 'trackHeight')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export type { Manager } from './manager';
 export type { HookOn, HooksOn, Plugin, HookType } from 'hooks-plugin';
 export type {
   Mode,
+  Distribution,
   Speed,
   StyleKey,
   Position,

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -42,6 +42,7 @@ export class Manager<
     this._internalStatuses.styles = Object.create(null);
     this._internalStatuses.styles.opacity = '';
     this.pluginSystem.lifecycle.init.emit(this);
+    this.options.overlap ??= 0;
   }
 
   /**
@@ -208,6 +209,7 @@ export class Manager<
     key?: Nullable<keyof ManagerOptions>,
   ) {
     this._engine.updateOptions(newOptions);
+    newOptions.overlap ??= this.options.overlap;
     this.options = Object.assign(this.options, newOptions);
 
     if (hasOwn(newOptions, 'interval')) {
@@ -442,6 +444,12 @@ export class Manager<
 
   public setDirection(direction: Exclude<Direction, 'none'>) {
     this.updateOptions({ direction }, 'direction');
+  }
+
+  public setOverlap(overlap: number) {
+    if (overlap < 0) overlap = 0;
+    if (overlap > 1) overlap = 1;
+    this.updateOptions({ overlap }, 'overlap');
   }
 
   public setLimits({ view, stash }: { view?: number; stash?: number }) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -448,7 +448,6 @@ export class Manager<
 
   public setOverlap(overlap: number) {
     if (overlap < 0) overlap = 0;
-    if (overlap > 1) overlap = 1;
     this.updateOptions({ overlap }, 'overlap');
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export type Direction = 'left' | 'right' | 'none';
 
 export type Mode = 'none' | 'strict' | 'adaptive';
 
+export type Distribution = 'random' | 'order';
+
 export type Speed = Nullable<string | number>;
 
 export type Layer<T> = StashData<T> | FacileDanmaku<T>;
@@ -75,6 +77,7 @@ export interface EngineOptions {
     view?: number;
     stash: number;
   };
+  distribution?: Distribution;
 }
 
 export interface ManagerOptions extends EngineOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export interface EngineOptions {
   mode: Mode;
   rate: number;
   gap: number | string;
+  overlap?: number;
   trackHeight: number | string;
   durationRange: [number, number];
   direction: Exclude<Direction, 'none'>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,8 +24,13 @@ export const getTrackIdx = (
       }
     }
   }
-  const n = Math.floor(Math.random() * rows);
+  const n = getTrackRandomIdx(rows);
   return founds.has(n) ? getTrackIdx(founds, rows, distribution) : n;
+};
+
+export const getTrackRandomIdx = (rows: number): number => {
+  const n = Math.floor(Math.random() * rows);
+  return n;
 };
 
 export const toNumber = (val: string, all: number) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { raf, once, mathExprEvaluate } from 'aidly';
+import { Distribution } from './types';
 
 export const INTERNAL_FLAG = Symbol();
 
@@ -11,9 +12,20 @@ export const ids = {
 
 export const nextFrame = (fn: FrameRequestCallback) => raf(() => raf(fn));
 
-export const randomIdx = (founds: Set<number>, rows: number): number => {
+export const getTrackIdx = (
+  founds: Set<number>,
+  rows: number,
+  distribution: Distribution = 'random',
+): number => {
+  if (distribution === 'order') {
+    for (let i = 0; i < rows; i++) {
+      if (!founds.has(i)) {
+        return i;
+      }
+    }
+  }
   const n = Math.floor(Math.random() * rows);
-  return founds.has(n) ? randomIdx(founds, rows) : n;
+  return founds.has(n) ? getTrackIdx(founds, rows, distribution) : n;
 };
 
 export const toNumber = (val: string, all: number) => {


### PR DESCRIPTION
I added this in my fork because my user asked for this. 

Added a `distribution` option to the engine to determine how danmu is allocated to tracks. By default each danmu randomly picks an open track, the `ordered` option makes it so that the top tracks are preferred.

random (Default):
<img width="1525" height="999" alt="image" src="https://github.com/user-attachments/assets/2b86be56-6b1b-40d2-a86b-57737e704d1c" />

ordered
<img width="1539" height="992" alt="image" src="https://github.com/user-attachments/assets/312bac97-fc74-4551-b4ee-545fdf10fa45" />

